### PR TITLE
Reintroduce coverage collection on integration-tests

### DIFF
--- a/integration-test/test.js
+++ b/integration-test/test.js
@@ -16,6 +16,12 @@ describe('in afterEach mode', function () {
     expect.addAssertion('<function> when run through (mocha|jest) <assertion>', (expect, subject) => {
         expect.errorMode = 'nested';
         const isMocha = expect.alternations[0] === 'mocha';
+
+        if (process.env.JEST === 'false' && expect.alternations[0] === 'jest') {
+            // Allow to disable jest assertions when running integration tests for coverage.
+            return expect(true, 'to be ok');
+        }
+
         const code = subject.toString().replace(/^[^{]+\{|\}\s*$/g, '');
         expect.subjectOutput = function (output) {
             output.code(code, 'javascript');

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test-mocha": "mocha --opts test/mocha/mocha.opts",
     "test-jest": "jest --config test/jest/jest.config.js",
     "travis": "npm test && npm run lint && npm run coverage && (<coverage/lcov.info coveralls || true)",
-    "coverage": "NODE_ENV=development nyc --reporter=lcov --reporter=text --all -- mocha && echo google-chrome coverage/lcov-report/index.html"
+    "coverage": "NODE_ENV=development nyc --reporter=lcov --reporter=text --all -- npm run coverage-test && echo google-chrome coverage/lcov-report/index.html",
+    "coverage-test": "npm run test-mocha && JEST=false npm run test-integration"
   },
   "author": "Andreas Lind <andreas@one.com>",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Coverage dropped after #4 as integration tests was split out from the generic tests.