### PR TITLE
Fix a rather tricky race within httpception.

### DIFF
--- a/lib/httpception.js
+++ b/lib/httpception.js
@@ -3,6 +3,7 @@ var UnexpectedMitmMocker = require('unexpected-mitm/lib/UnexpectedMitmMocker');
 var resolveFromAfterEach;
 var mocker;
 var promise;
+var promiseFactoryForCurrentTest;
 var mockDefinitionForTheCurrentTest;
 
 var afterEachRegistered = false;
@@ -72,7 +73,19 @@ module.exports = function httpception(mockDefinition, promiseFactory) {
     });
 
   if (promiseFactory) {
-    resolveFromAfterEach = false;
+    promiseFactoryForCurrentTest = promiseFactory;
+
+    if (resolveFromAfterEach) {
+      // We were previously called to enqueue a mock. Critically, this created
+      // a partially open mocker.. we MUST use that initial instance rather than
+      // create a new instance. Latch the promise factory into the existing chain.
+      const quietedPromise = promiseFactory().catch(() => {});
+      resolveFromAfterEach(quietedPromise);
+      resolveFromAfterEach = undefined;
+      const promiseToReturn = promise;
+      promise = undefined;
+      return promiseToReturn;
+    }
 
     return mocker
       .mock(promiseFactory)
@@ -103,8 +116,13 @@ module.exports = function httpception(mockDefinition, promiseFactory) {
 
     promise = Promise.all([resolvePromise, mockerPromise])
       .then(result => {
+        const functionToInspect =
+          promiseFactoryForCurrentTest || function afterEach() {};
+
+        promiseFactoryForCurrentTest = undefined;
+
         return expect(
-          function afterEach() {},
+          functionToInspect,
           'to perform HTTP traffic',
           mocker.requestDescriptions
         );


### PR DESCRIPTION
When httpception was converted to directly instantiate a mocker it
had to make the instance early. This created a nasty situation when
mocks are queued. If we then see a promise factory block we need to
exhaust the already created mocker - arrange this.